### PR TITLE
No need to check if there is _pushHistory when navigating

### DIFF
--- a/backbone-beforepopstate.js
+++ b/backbone-beforepopstate.js
@@ -71,7 +71,7 @@ Backbone.addBeforePopState = function(BB) {
     // If there are beforepushstate handlers, continue as normal
     var events = jQuery(window).data('events') || jQuery._data(jQuery(window)[0], 'events');
     var cancelled = false;
-    if (events && events.beforepushstate && BB.history._pushHistory.length > 0) {
+    if (events && events.beforepushstate) {
       // Try each beforepushstate handler, retrieving the text
       // and then checking with the user
       for (var i = 0; i < events.beforepushstate.length; i++) {


### PR DESCRIPTION
Removes check for empty `._pushHistory` inside `navigate()`.

Bug:
When trying to navigate from the first page after load,  `._pushHistory` is empty. The prompt does not appear when moving away from this page. I think the `BB.history._pushHistory.length > 0` check is relevant only on `popState`, not on `pushState`.
